### PR TITLE
feat: ajout du type utilisateur mission-apprentissage et update des comptes existants

### DIFF
--- a/server/src/migrations/20240904102312-update-mia-users.ts
+++ b/server/src/migrations/20240904102312-update-mia-users.ts
@@ -1,0 +1,23 @@
+import { getDbCollection } from "@/services/mongodb/mongodbService.js";
+
+export const up = async () => {
+  await getDbCollection("users").updateMany(
+    {
+      email: {
+        $in: [
+          "moroine.bentefrit@beta.gouv.fr",
+          "antoine.bigard@beta.gouv.fr",
+          "kevin.barnoin@beta.gouv.fr",
+          "leo.radisson@beta.gouv.fr",
+          "samir.benfares@beta.gouv.fr",
+          "sofia.boulaarab@beta.gouv.fr",
+          "marion.guillet@beta.gouv.fr",
+          "claire.arnaud@beta.gouv.fr",
+          "tdb@alternance.beta.gouv.fr",
+          "catherine.bourreau@beta.gouv.fr",
+        ],
+      },
+    },
+    { $set: { type: "mission_apprentissage" } }
+  );
+};

--- a/shared/src/models/user.model.ts
+++ b/shared/src/models/user.model.ts
@@ -55,6 +55,7 @@ export const zUser = z
       "editeur_logiciel",
       "organisme_financeur",
       "apprenant",
+      "mission_apprentissage",
       "autre",
     ]),
     activite: z

--- a/ui/app/auth/inscription/page.tsx
+++ b/ui/app/auth/inscription/page.tsx
@@ -203,6 +203,7 @@ export default function RegisterPage() {
               <option value="editeur_logiciel">Editeur de logiciel</option>
               <option value="organisme_financeur">Organisme financeur</option>
               <option value="apprenant">Apprenant</option>
+              <option value="mission_apprentissage">Mission Apprentissage</option>
               <option value="autre">Autre</option>
             </Select>
             <Input


### PR DESCRIPTION
Pour le monitoring dans la page stats des comptes de la mission, besoin d'avoir l'information type utilisateur "MIA".

- Ajout d'une entrée "Mission apprentissage" au formulaire d'inscription et au modèle
- Ajout d'une migration d'update des comptes existants