### PR TITLE
feat: ajout du lien page statistiques dans le footer

### DIFF
--- a/server/src/migrations/20240904102312-update-mia-users.ts
+++ b/server/src/migrations/20240904102312-update-mia-users.ts
@@ -1,0 +1,23 @@
+import { getDbCollection } from "@/services/mongodb/mongodbService.js";
+
+export const up = async () => {
+  await getDbCollection("users").updateMany(
+    {
+      email: {
+        $in: [
+          "moroine.bentefrit@beta.gouv.fr",
+          "antoine.bigard@beta.gouv.fr",
+          "kevin.barnoin@beta.gouv.fr",
+          "leo.radisson@beta.gouv.fr",
+          "samir.benfares@beta.gouv.fr",
+          "sofia.boulaarab@beta.gouv.fr",
+          "marion.guillet@beta.gouv.fr",
+          "claire.arnaud@beta.gouv.fr",
+          "tdb@alternance.beta.gouv.fr",
+          "catherine.bourreau@beta.gouv.fr",
+        ],
+      },
+    },
+    { $set: { type: "mission_apprentissage" } }
+  );
+};

--- a/shared/src/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
+++ b/shared/src/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
@@ -7259,6 +7259,7 @@ exports[`zodToMongoSchema > should convert users schema 1`] = `
         "editeur_logiciel",
         "organisme_financeur",
         "apprenant",
+        "mission_apprentissage",
         "autre",
       ],
     },

--- a/shared/src/models/user.model.ts
+++ b/shared/src/models/user.model.ts
@@ -78,7 +78,6 @@ export const zUser = z
     updated_at: z.date().describe("Date de mise à jour en base de données"),
     created_at: z.date().describe("Date d'ajout en base de données"),
   })
-  .strict();
 
 export const zUserCreate = zUser.pick({
   email: true,

--- a/shared/src/models/user.model.ts
+++ b/shared/src/models/user.model.ts
@@ -46,36 +46,39 @@ export const zApiKeyPrivate = zApiKey.omit({ key: true }).extend({
 export type IApiKeyPrivate = z.output<typeof zApiKeyPrivate>;
 export type IApiKeyPrivateJson = Jsonify<IApiKeyPrivate>;
 
-export const zUser = z.object({
-  _id: zObjectId,
-  organisation: z.string().nullable(),
-  email: z.string().email().describe("Email de l'utilisateur").toLowerCase(),
-  type: z.enum([
-    "operateur_public",
-    "organisme_formation",
-    "entreprise",
-    "editeur_logiciel",
-    "organisme_financeur",
-    "apprenant",
-    "autre",
-  ]),
-  activite: z
-    .string()
-    .trim()
-    .nullable()
-    .transform((v) => v || null),
-  objectif: z.enum(["fiabiliser", "concevoir"]).nullable(),
-  cas_usage: z
-    .string()
-    .trim()
-    .nullable()
-    .transform((v) => v || null),
-  cgu_accepted_at: z.date(),
-  is_admin: z.boolean(),
-  api_keys: z.array(zApiKey),
-  updated_at: z.date().describe("Date de mise à jour en base de données"),
-  created_at: z.date().describe("Date d'ajout en base de données"),
-});
+export const zUser = z
+  .object({
+    _id: zObjectId,
+    organisation: z.string().nullable(),
+    email: z.string().email().describe("Email de l'utilisateur").toLowerCase(),
+    type: z.enum([
+      "operateur_public",
+      "organisme_formation",
+      "entreprise",
+      "editeur_logiciel",
+      "organisme_financeur",
+      "apprenant",
+      "mission_apprentissage",
+      "autre",
+    ]),
+    activite: z
+      .string()
+      .trim()
+      .nullable()
+      .transform((v) => v || null),
+    objectif: z.enum(["fiabiliser", "concevoir"]).nullable(),
+    cas_usage: z
+      .string()
+      .trim()
+      .nullable()
+      .transform((v) => v || null),
+    cgu_accepted_at: z.date(),
+    is_admin: z.boolean(),
+    api_keys: z.array(zApiKey),
+    updated_at: z.date().describe("Date de mise à jour en base de données"),
+    created_at: z.date().describe("Date d'ajout en base de données"),
+  })
+  .strict();
 
 export const zUserCreate = zUser.pick({
   email: true,

--- a/shared/src/models/user.model.ts
+++ b/shared/src/models/user.model.ts
@@ -46,38 +46,37 @@ export const zApiKeyPrivate = zApiKey.omit({ key: true }).extend({
 export type IApiKeyPrivate = z.output<typeof zApiKeyPrivate>;
 export type IApiKeyPrivateJson = Jsonify<IApiKeyPrivate>;
 
-export const zUser = z
-  .object({
-    _id: zObjectId,
-    organisation: z.string().nullable(),
-    email: z.string().email().describe("Email de l'utilisateur").toLowerCase(),
-    type: z.enum([
-      "operateur_public",
-      "organisme_formation",
-      "entreprise",
-      "editeur_logiciel",
-      "organisme_financeur",
-      "apprenant",
-      "mission_apprentissage",
-      "autre",
-    ]),
-    activite: z
-      .string()
-      .trim()
-      .nullable()
-      .transform((v) => v || null),
-    objectif: z.enum(["fiabiliser", "concevoir"]).nullable(),
-    cas_usage: z
-      .string()
-      .trim()
-      .nullable()
-      .transform((v) => v || null),
-    cgu_accepted_at: z.date(),
-    is_admin: z.boolean(),
-    api_keys: z.array(zApiKey),
-    updated_at: z.date().describe("Date de mise à jour en base de données"),
-    created_at: z.date().describe("Date d'ajout en base de données"),
-  })
+export const zUser = z.object({
+  _id: zObjectId,
+  organisation: z.string().nullable(),
+  email: z.string().email().describe("Email de l'utilisateur").toLowerCase(),
+  type: z.enum([
+    "operateur_public",
+    "organisme_formation",
+    "entreprise",
+    "editeur_logiciel",
+    "organisme_financeur",
+    "apprenant",
+    "mission_apprentissage",
+    "autre",
+  ]),
+  activite: z
+    .string()
+    .trim()
+    .nullable()
+    .transform((v) => v || null),
+  objectif: z.enum(["fiabiliser", "concevoir"]).nullable(),
+  cas_usage: z
+    .string()
+    .trim()
+    .nullable()
+    .transform((v) => v || null),
+  cgu_accepted_at: z.date(),
+  is_admin: z.boolean(),
+  api_keys: z.array(zApiKey),
+  updated_at: z.date().describe("Date de mise à jour en base de données"),
+  created_at: z.date().describe("Date d'ajout en base de données"),
+});
 
 export const zUserCreate = zUser.pick({
   email: true,

--- a/ui/app/auth/inscription/page.tsx
+++ b/ui/app/auth/inscription/page.tsx
@@ -205,6 +205,7 @@ export default function RegisterPage() {
               <option value="editeur_logiciel">Editeur de logiciel</option>
               <option value="organisme_financeur">Organisme financeur</option>
               <option value="apprenant">Apprenant</option>
+              <option value="mission_apprentissage">Mission Apprentissage</option>
               <option value="autre">Autre</option>
             </Select>
             <Input

--- a/ui/components/Footer.tsx
+++ b/ui/components/Footer.tsx
@@ -70,6 +70,15 @@ const Footer = () => {
             },
           }}
         />,
+        <FooterBottomItem
+          key="statistiques"
+          bottomItem={{
+            text: "Statistiques",
+            linkProps: {
+              href: `http://api.apprentissage.beta.gouv.fr/metabase/public/dashboard/240019b1-0f17-4e7c-bf52-a297476d486f`,
+            },
+          }}
+        />,
       ]}
     />
   );


### PR DESCRIPTION
Ajout de la page statistiques (lien Metabase) au footer.
Pour le monitoring dans la page stats des comptes de la mission, besoin d'avoir l'information type utilisateur "MIA".

- Ajout d'une entrée "Mission apprentissage" au formulaire d'inscription et au modèle
- Ajout d'une migration d'update des comptes existants