### PR TITLE
fix: update de la regex code Rome

### DIFF
--- a/sdk/src/models/certification/certification.model.openapi.ts
+++ b/sdk/src/models/certification/certification.model.openapi.ts
@@ -208,7 +208,7 @@ const schema: SchemaObject = {
                 properties: {
                   code: {
                     type: "string",
-                    pattern: "^[A-Z]{1}\\d{2,4}$",
+                    pattern: "^[A-Z]{1}\\d{0,4}$",
                   },
                   intitule: {
                     type: "string",

--- a/sdk/src/models/certification/certification.primitives.ts
+++ b/sdk/src/models/certification/certification.primitives.ts
@@ -25,7 +25,7 @@ export const zNsfCode = z.string().regex(/^\d{2,3}[a-z]?$/);
 
 export const zRomeCode = z.string().regex(/^[A-Z]{1}\d{4}$/);
 
-export const zRomeCodeFlex = z.string().regex(/^[A-Z]{1}\d{2,4}$/);
+export const zRomeCodeFlex = z.string().regex(/^[A-Z]{1}\d{0,4}$/);
 
 export const zCfdNatureCode = z.string().regex(/^[0-9A-Z]$/);
 

--- a/server/src/jobs/importer/bcn/bcn.importer.ts
+++ b/server/src/jobs/importer/bcn/bcn.importer.ts
@@ -206,6 +206,6 @@ export async function runBcnImporter(): Promise<Record<string, unknown>> {
     return statsBySource;
   } catch (error) {
     await getDbCollection("import.meta").updateOne({ _id: importId }, { $set: { status: "failed" } });
-    throw withCause(internal("import.bcn: unable to runBcnImporter"), error);
+    throw withCause(internal("import.bcn: unable to runBcnImporter"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/certifications/certifications.importer.ts
+++ b/server/src/jobs/importer/certifications/certifications.importer.ts
@@ -384,6 +384,6 @@ export async function importCertifications(options: ImportCertificationsOptions 
     await getDbCollection("import.meta").updateOne({ _id: importMeta._id }, { $set: { status: "failed" } });
     await getDbCollection("certifications").deleteMany({ updated_at: importMeta.import_date });
 
-    throw withCause(internal("import.certifications: unable to importCertifications"), error);
+    throw withCause(internal("import.certifications: unable to importCertifications"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/dares/ape_idcc/dares.ape_idcc.importer.ts
+++ b/server/src/jobs/importer/dares/ape_idcc/dares.ape_idcc.importer.ts
@@ -120,6 +120,6 @@ export async function runDaresApeIdccImporter(signal?: AbortSignal) {
     if (signal && error.name === signal?.reason?.name) {
       throw signal.reason;
     }
-    throw withCause(internal("import.dares_ape_idcc: unable to runDaresApeIdccImporter"), error);
+    throw withCause(internal("import.dares_ape_idcc: unable to runDaresApeIdccImporter"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/dares/ape_idcc/scraper/dares.ape_idcc.scraper.ts
+++ b/server/src/jobs/importer/dares/ape_idcc/scraper/dares.ape_idcc.scraper.ts
@@ -58,6 +58,10 @@ export async function downloadResourceApeIdccFile(resource: IImportMetaDares["re
 
     return await downloadFileAsStream(response.data, new URL(resource.url).pathname.split("/").pop() ?? "");
   } catch (error) {
-    throw withCause(internal("dares.ape_idcc.scraper: unable to downloadResourceCcnFile", { resource }), error);
+    throw withCause(
+      internal("dares.ape_idcc.scraper: unable to downloadResourceCcnFile", { resource }),
+      error,
+      "fatal"
+    );
   }
 }

--- a/server/src/jobs/importer/dares/ccn/dares.ccn.importer.ts
+++ b/server/src/jobs/importer/dares/ccn/dares.ccn.importer.ts
@@ -112,6 +112,6 @@ export async function runDaresConventionCollectivesImporter(signal?: AbortSignal
     if (signal && error.name === signal?.reason?.name) {
       throw signal.reason;
     }
-    throw withCause(internal("import.dares_ccn: unable to runDaresConventionCollectivesImporter"), error);
+    throw withCause(internal("import.dares_ccn: unable to runDaresConventionCollectivesImporter"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/dares/ccn/scraper/dares.ccn.scraper.ts
+++ b/server/src/jobs/importer/dares/ccn/scraper/dares.ccn.scraper.ts
@@ -64,6 +64,6 @@ export async function downloadResourceCcnFile(resource: IImportMetaDares["resour
 
     return await downloadFileAsStream(response.data, new URL(resource.url).pathname.split("/").pop() ?? "");
   } catch (error) {
-    throw withCause(internal("dares.ccn.scraper: unable to downloadResourceCcnFile", { resource }), error);
+    throw withCause(internal("dares.ccn.scraper: unable to downloadResourceCcnFile", { resource }), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/france_competence/france_competence.importer.ts
+++ b/server/src/jobs/importer/france_competence/france_competence.importer.ts
@@ -441,7 +441,7 @@ export async function importRncpArchive(importMeta: IImportMetaFranceCompetence,
     if (signal && error.name === signal?.reason?.name) {
       throw signal.reason;
     }
-    throw withCause(internal("import.france_competence: unable to importRncpArchive", { importMeta }), error);
+    throw withCause(internal("import.france_competence: unable to importRncpArchive", { importMeta }), error, "fatal");
   }
 }
 
@@ -449,7 +449,7 @@ export async function onImportRncpArchiveFailure(importMeta: IImportMetaFranceCo
   try {
     await getDbCollection("import.meta").updateOne({ _id: importMeta._id }, { $set: { status: "failed" } });
   } catch (error) {
-    throw withCause(internal("import.france_competence: unable to onImportRncpArchiveFailure"), error);
+    throw withCause(internal("import.france_competence: unable to onImportRncpArchiveFailure"), error, "fatal");
   }
 }
 
@@ -512,6 +512,6 @@ export async function runRncpImporter() {
       archives: importMetas.map((meta) => meta.archiveMeta.nom),
     };
   } catch (error) {
-    throw withCause(internal("import.france_competence: unable to runRncpImporter"), error);
+    throw withCause(internal("import.france_competence: unable to runRncpImporter"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/kali/kali.ccn.importer.ts
+++ b/server/src/jobs/importer/kali/kali.ccn.importer.ts
@@ -142,6 +142,6 @@ export async function runKaliConventionCollectivesImporter(signal?: AbortSignal)
     await getDbCollection("import.meta").updateOne({ _id: importId }, { $set: { status: "done" } });
   } catch (error) {
     await getDbCollection("import.meta").updateOne({ _id: importId }, { $set: { status: "failed" } });
-    throw withCause(internal("import.kali_ccn: unable to runKaliConventionCollectivesImporter"), error);
+    throw withCause(internal("import.kali_ccn: unable to runKaliConventionCollectivesImporter"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/kit/kitApprentissage.importer.ts
+++ b/server/src/jobs/importer/kit/kitApprentissage.importer.ts
@@ -170,6 +170,6 @@ export async function runKitApprentissageImporter(): Promise<number> {
   } catch (error) {
     await getDbCollection("import.meta").updateOne({ _id: importId }, { $set: { status: "failed" } });
     await getDbCollection("source.kit_apprentissage").deleteMany({ date: importDate });
-    throw withCause(internal("import.kit_apprentissage: unable to runKitApprentissageImporter"), error);
+    throw withCause(internal("import.kit_apprentissage: unable to runKitApprentissageImporter"), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/npec/normalizer/npec.normalizer.ts
+++ b/server/src/jobs/importer/npec/normalizer/npec.normalizer.ts
@@ -219,6 +219,6 @@ export async function runNpecNormalizer(importMeta: IImportMetaNpec) {
       date_import: importMeta.import_date,
       filename,
     });
-    throw withCause(internal("npec.import.normalizer: unable to runNpecNormalizer", { importMeta }), error);
+    throw withCause(internal("npec.import.normalizer: unable to runNpecNormalizer", { importMeta }), error, "fatal");
   }
 }

--- a/server/src/jobs/importer/npec/npec.importer.ts
+++ b/server/src/jobs/importer/npec/npec.importer.ts
@@ -363,7 +363,7 @@ export async function importNpecResource(importMeta: IImportMetaNpec, signal?: A
       date_import: importMeta.import_date,
       filename,
     });
-    throw withCause(internal("npec.import: unable to importNpecResource", { importMeta }), error);
+    throw withCause(internal("npec.import: unable to importNpecResource", { importMeta }), error, "fatal");
   }
 }
 
@@ -371,7 +371,7 @@ export async function onImportNpecResourceFailure(importMeta: IImportMetaNpec) {
   try {
     await getDbCollection("import.meta").updateOne({ _id: importMeta._id }, { $set: { status: "failed" } });
   } catch (error) {
-    throw withCause(internal("npec.import: unable to update import_meta status", { importMeta }), error);
+    throw withCause(internal("npec.import: unable to update import_meta status", { importMeta }), error, "fatal");
   }
 }
 
@@ -441,6 +441,6 @@ export async function runNpecImporter() {
       await getDbCollection("import.meta").updateOne({ _id: importMeta._id }, { $set: { status: "pending" } });
     }
   } catch (error) {
-    throw withCause(internal("npec.importer: error while running importer"), error);
+    throw withCause(internal("npec.importer: error while running importer"), error, "fatal");
   }
 }

--- a/server/src/services/errors/withCause.ts
+++ b/server/src/services/errors/withCause.ts
@@ -1,7 +1,7 @@
 import { captureException } from "@sentry/node";
 
-export function withCause<T extends Error>(error: T, cause: Error): T {
+export function withCause<T extends Error>(error: T, cause: Error, level: "fatal" | "error" | "warning" = "error"): T {
   error.cause = cause;
-  captureException(cause);
+  captureException(cause, { level });
   return error;
 }

--- a/shared/src/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
+++ b/shared/src/helpers/mongoSchema/__snapshots__/mongoSchemaBuilder.test.ts.snap
@@ -450,7 +450,7 @@ exports[`zodToMongoSchema > should convert certifications schema 1`] = `
                     "properties": {
                       "code": {
                         "bsonType": "string",
-                        "pattern": "^[A-Z]{1}\\d{2,4}$",
+                        "pattern": "^[A-Z]{1}\\d{0,4}$",
                       },
                       "intitule": {
                         "bsonType": "string",

--- a/shared/src/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/src/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -906,7 +906,7 @@ Notes:
                           "examples": [
                             "D1102",
                           ],
-                          "pattern": "^[A-Z]{1}\\d{2,4}$",
+                          "pattern": "^[A-Z]{1}\\d{0,4}$",
                           "type": "string",
                         },
                         "intitule": {


### PR DESCRIPTION
Proposition de fix de l'anomalie de build des certifications lié potentiellement à un code rome au mauvais format : 

`{"Codes_Rome_Code":"C","Codes_Rome_Libelle":"BANQUE, ASSURANCES ET IMMOBILIER","Numero_Fiche":"RNCP38273"}`

Mise à jour de la Regex pour temporairement autoriser les codes au mauvais format en attendant la correction à la source
👉🏼 https://tableaudebord-apprentissage.atlassian.net/browse/AA-589
