### PR TITLE
feat(server): set workplace_idcc as string as lba source

### DIFF
--- a/sdk/src/client/internal/job/job.module.test.ts
+++ b/sdk/src/client/internal/job/job.module.test.ts
@@ -42,7 +42,7 @@ describe("search", () => {
             },
           },
           domain: {
-            idcc: 1242,
+            idcc: "1242",
             opco: "",
             naf: {
               code: "84.11Z",

--- a/sdk/src/external/laBonneAlternance.api.test.ts
+++ b/sdk/src/external/laBonneAlternance.api.test.ts
@@ -29,7 +29,7 @@ type IJobWorkplaceExpected = {
     type: "Point";
     coordinates: [number, number];
   };
-  workplace_idcc: number | null;
+  workplace_idcc: string | null;
   workplace_opco: string | null;
   workplace_naf_code: string | null;
   workplace_naf_label: string | null;

--- a/sdk/src/models/job/job.model.test.ts
+++ b/sdk/src/models/job/job.model.test.ts
@@ -23,7 +23,7 @@ type IJobRecruiterExpected = {
       };
     };
     domain: {
-      idcc: number | null;
+      idcc: string | null;
       opco: string | null;
       naf: null | {
         code: string;

--- a/sdk/src/models/job/job.model.ts
+++ b/sdk/src/models/job/job.model.ts
@@ -36,7 +36,7 @@ const zJobRecruiterWorkplace = zJobRecruiterWorkplaceWritable
     size: z.string().nullable(),
 
     domain: z.object({
-      idcc: z.number().nullable(),
+      idcc: z.string().nullable(),
       opco: z.string().nullable(),
       naf: z
         .object({
@@ -179,4 +179,4 @@ type IJobRecruiter = z.output<typeof zJobRecruiter>;
 
 export type { IJobOffer, IJobOfferWritable, IJobRecruiter };
 
-export { zJobRecruiter, zJobOffer, zJobOfferWritable };
+export { zJobOffer, zJobOfferWritable, zJobRecruiter };

--- a/server/src/server/routes/job/job.route.test.ts
+++ b/server/src/server/routes/job/job.route.test.ts
@@ -107,7 +107,7 @@ describe("GET /job/v1/search", () => {
             coordinates: [2.347, 48.8589],
             type: "Point",
           },
-          workplace_idcc: 1242,
+          workplace_idcc: "1242",
           workplace_legal_name: "ASSEMBLEE NATIONALE",
           workplace_naf_code: "84.11Z",
           workplace_naf_label: "Autorité constitutionnelle",
@@ -173,7 +173,7 @@ describe("GET /job/v1/search", () => {
               },
             },
             domain: {
-              idcc: 1242,
+              idcc: "1242",
               opco: "",
               naf: {
                 code: "84.11Z",

--- a/server/src/services/apis/lba/lba.api.test.ts
+++ b/server/src/services/apis/lba/lba.api.test.ts
@@ -58,7 +58,7 @@ describe("searchJobOpportunities", () => {
           coordinates: [2.347, 48.8589],
           type: "Point",
         },
-        workplace_idcc: 1242,
+        workplace_idcc: "1242",
         workplace_legal_name: "ASSEMBLEE NATIONALE",
         workplace_naf_code: "84.11Z",
         workplace_naf_label: "Autorité constitutionnelle",

--- a/server/src/services/jobs/job.service.test.ts
+++ b/server/src/services/jobs/job.service.test.ts
@@ -44,7 +44,7 @@ describe("convertJobSearchResponseLbaToApi", () => {
             coordinates: [2.347, 48.8589],
             type: "Point",
           },
-          workplace_idcc: 1242,
+          workplace_idcc: "1242",
           workplace_legal_name: "ASSEMBLEE NATIONALE",
           workplace_naf_code: "84.11Z",
           workplace_naf_label: "Autorité constitutionnelle",
@@ -110,7 +110,7 @@ describe("convertJobSearchResponseLbaToApi", () => {
               },
             },
             domain: {
-              idcc: 1242,
+              idcc: "1242",
               opco: "",
               naf: {
                 code: "84.11Z",

--- a/shared/src/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/src/helpers/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -251,7 +251,58 @@ exports[`generateOpenApiSchema > should be alright /job/v1/offer/{id} 1`] = `
 ]
 `;
 
-exports[`generateOpenApiSchema > should be alright /job/v1/search 1`] = `[]`;
+exports[`generateOpenApiSchema > should be alright /job/v1/search 1`] = `
+[
+  {
+    "oldValue": "number",
+    "path": [
+      "get",
+      "responses",
+      "200",
+      "content",
+      "application/json",
+      "schema",
+      "properties",
+      "jobs",
+      "items",
+      "properties",
+      "workplace",
+      "properties",
+      "domain",
+      "properties",
+      "idcc",
+      "type",
+      0,
+    ],
+    "type": "CHANGE",
+    "value": "string",
+  },
+  {
+    "oldValue": "number",
+    "path": [
+      "get",
+      "responses",
+      "200",
+      "content",
+      "application/json",
+      "schema",
+      "properties",
+      "recruiters",
+      "items",
+      "properties",
+      "workplace",
+      "properties",
+      "domain",
+      "properties",
+      "idcc",
+      "type",
+      0,
+    ],
+    "type": "CHANGE",
+    "value": "string",
+  },
+]
+`;
 
 exports[`generateOpenApiSchema > should be alright /organisme/v1/recherche 1`] = `[]`;
 


### PR DESCRIPTION
- IDCC data is hosted as a string on LBA, changes made accordingly. 
- linked PR : https://github.com/mission-apprentissage/labonnealternance/pull/1618