### PR TITLE
fix: france competence import race condition

### DIFF
--- a/server/src/jobs/importer/certifications/certifications.importer.ts
+++ b/server/src/jobs/importer/certifications/certifications.importer.ts
@@ -37,8 +37,11 @@ type ImportCertificationsOptions = {
 
 async function getSourceImportMeta(): Promise<IImportMetaCertifications["source"] | null> {
   const [kitApprentissage, bcn, franceCompetenceLatest, oldestFranceCompetence] = await Promise.all([
-    getDbCollection("import.meta").findOne({ type: "kit_apprentissage" }, { sort: { import_date: -1 } }),
-    getDbCollection("import.meta").findOne({ type: "bcn" }, { sort: { import_date: -1 } }),
+    getDbCollection("import.meta").findOne(
+      { type: "kit_apprentissage", status: "done" },
+      { sort: { import_date: -1 } }
+    ),
+    getDbCollection("import.meta").findOne({ type: "bcn", status: "done" }, { sort: { import_date: -1 } }),
     getDbCollection("import.meta").findOne<IImportMetaFranceCompetence>(
       { type: "france_competence", status: "done" },
       { sort: { import_date: -1, "archiveMeta.nom": -1 } }

--- a/server/src/jobs/importer/france_competence/france_competence.importer.ts
+++ b/server/src/jobs/importer/france_competence/france_competence.importer.ts
@@ -396,6 +396,15 @@ async function indicateurContinuity(
 
 export async function importRncpArchive(importMeta: IImportMetaFranceCompetence, signal?: AbortSignal) {
   try {
+    await getDbCollection("import.meta").updateOne(
+      { _id: importMeta._id },
+      {
+        $set: {
+          import_date: new Date(),
+        },
+      }
+    );
+
     const readStream = await downloadDataGouvResource(importMeta.archiveMeta.resource);
 
     if (signal) addAbortSignal(signal, readStream);


### PR DESCRIPTION
De l'import FC dépend l'import des certifications. Cette PR résout le cas suivant:

- `import:france_competence` crée 2 resources à importer
- `import:france_competence:resource` importe la premiere ressource
- `import:certifications` mets à jour les certifications car il y a un nouvel import terminé (import_date plus récente).
- `import:france_competence:resource` importe la seconde ressource
- `import:certifications` ne fait rien car la date d'import est identique.