### PR TITLE
feat: ajout de mécanisme de suppression d'organisation

### DIFF
--- a/server/src/actions/organisations.actions.ts
+++ b/server/src/actions/organisations.actions.ts
@@ -1,0 +1,21 @@
+import { notFound } from "@hapi/boom";
+import type { ObjectId } from "mongodb";
+
+import { getDbCollection } from "@/services/mongodb/mongodbService.js";
+
+export async function deleteOrganisation(organisationIdToDelete: ObjectId) {
+  const organisation = await getDbCollection("organisations").findOne(
+    { _id: organisationIdToDelete },
+    { projection: { nom: 1 } }
+  );
+  if (!organisation?.nom) throw notFound();
+  await removeOrganisationFromUsers(organisation.nom);
+  await getDbCollection("organisations").deleteOne({ _id: organisationIdToDelete });
+}
+
+function removeOrganisationFromUsers(organisationName: string) {
+  return getDbCollection("users").updateMany(
+    { organisation: organisationName },
+    { $set: { organisation: null, updated_at: new Date() } }
+  );
+}

--- a/server/src/actions/organisations.actions.ts
+++ b/server/src/actions/organisations.actions.ts
@@ -8,7 +8,7 @@ export async function deleteOrganisation(organisationIdToDelete: ObjectId) {
     { _id: organisationIdToDelete },
     { projection: { nom: 1 } }
   );
-  if (!organisation?.nom) throw notFound();
+  if (!organisation) throw notFound();
   await removeOrganisationFromUsers(organisation.nom);
   await getDbCollection("organisations").deleteOne({ _id: organisationIdToDelete });
 }

--- a/server/src/server/routes/_private/admin/organisations.routes.ts
+++ b/server/src/server/routes/_private/admin/organisations.routes.ts
@@ -3,6 +3,7 @@ import { ObjectId } from "mongodb";
 import { zRoutes } from "shared";
 import type { IOrganisationInternal } from "shared/models/organisation.model";
 
+import { deleteOrganisation } from "@/actions/organisations.actions.js";
 import type { Server } from "@/server/server.js";
 import { getDbCollection } from "@/services/mongodb/mongodbService.js";
 
@@ -68,6 +69,18 @@ export const organisationAdminRoutes = ({ server }: { server: Server }) => {
       }
 
       return response.status(200).send(organisation);
+    }
+  );
+
+  server.delete(
+    "/_private/admin/organisations/:id",
+    {
+      schema: zRoutes.delete["/_private/admin/organisations/:id"],
+      onRequest: [server.auth(zRoutes.delete["/_private/admin/organisations/:id"])],
+    },
+    async (request, response) => {
+      await deleteOrganisation(request.params.id);
+      return response.status(200).send({ success: true });
     }
   );
 };

--- a/shared/src/routes/_private/admin/organisation.admin.routes.ts
+++ b/shared/src/routes/_private/admin/organisation.admin.routes.ts
@@ -44,4 +44,19 @@ export const zOrganisationAdminRoutes = {
       },
     },
   },
+  delete: {
+    "/_private/admin/organisations/:id": {
+      method: "delete",
+      path: "/_private/admin/organisations/:id",
+      params: z.object({ id: zObjectId }),
+      response: {
+        "200": z.object({ success: z.literal(true) }).strict(),
+      },
+      securityScheme: {
+        auth: "cookie-session",
+        access: "admin",
+        ressources: {},
+      },
+    },
+  },
 } as const satisfies IApiRoutesDef;

--- a/shared/src/routes/index.ts
+++ b/shared/src/routes/index.ts
@@ -46,6 +46,7 @@ const zRoutesPut = {
 const zRoutesDelete = {
   ...zUserRoutes.delete,
   ...zApiRoutesDelete,
+  ...zOrganisationAdminRoutes.delete,
 } as const;
 
 export type IGetRoutes = typeof zRoutesGet;

--- a/ui/app/[lang]/admin/hooks/useDeleteOrganisation.ts
+++ b/ui/app/[lang]/admin/hooks/useDeleteOrganisation.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import type { IDeleteRoutes, IParam } from "shared";
+import { zRoutes } from "shared";
+import type { IOrganisationInternal } from "shared/models/organisation.model";
+import type { Jsonify } from "type-fest";
+
+import { apiDelete } from "@/utils/api.utils";
+
+export type IDeleteOrganisationInput = Jsonify<IParam<IDeleteRoutes["/_private/admin/organisations/:id"]>>;
+
+export function useDeleteOrganisation() {
+  const queryClient = useQueryClient();
+  const { push } = useRouter();
+
+  const mutation = useMutation({
+    mutationFn: async (data: IDeleteOrganisationInput) => {
+      await apiDelete("/_private/admin/organisations/:id", { params: data });
+      return data.id;
+    },
+    onMutate: async (data) => {
+      await queryClient.cancelQueries({ queryKey: [zRoutes.get["/_private/admin/organisations"]] });
+
+      const previousOrganisations = queryClient.getQueryData<IOrganisationInternal[]>([
+        zRoutes.get["/_private/admin/organisations"],
+      ]);
+
+      queryClient.setQueryData<IOrganisationInternal[]>([zRoutes.get["/_private/admin/organisations"]], (oldData) =>
+        oldData ? oldData.filter((organisation) => organisation._id.toString() !== data.id) : []
+      );
+
+      return { previousOrganisations };
+    },
+    onError: (_error, _data, context) => {
+      if (context?.previousOrganisations) {
+        queryClient.setQueryData([zRoutes.get["/_private/admin/organisations"]], context.previousOrganisations);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [zRoutes.get["/_private/admin/organisations"]] });
+    },
+    onSuccess: () => {
+      push("/admin/organisations");
+    },
+  });
+
+  return mutation;
+}

--- a/ui/app/[lang]/admin/organisations/components/OrganisationList.tsx
+++ b/ui/app/[lang]/admin/organisations/components/OrganisationList.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { fr } from "@codegouvfr/react-dsfr";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import { Box, Typography } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
 
+import { useDeleteOrganisation } from "@/app/[lang]/admin/hooks/useDeleteOrganisation";
 import Loading from "@/app/[lang]/loading";
 import type { WithLang } from "@/app/i18n/settings";
 import { Table } from "@/components/table/Table";
@@ -12,18 +18,42 @@ import { PAGES } from "@/utils/routes.utils";
 import { CreateOrganisation } from "./CreateOrganisation";
 
 export default function OrganisationList({ lang }: WithLang) {
+  const deleteOrganisation = useDeleteOrganisation();
+  const [selectedOrganisation, setSelectedOrganisation] = useState<{ id: string; name: string } | null>(null);
+
+  const modal = useMemo(
+    () =>
+      createModal({
+        id: "confirm-delete-organisation-modal",
+        isOpenedByDefault: false,
+      }),
+    []
+  );
+
   const result = useQuery({
     queryKey: ["/_private/admin/organisations"],
     queryFn: async () => apiGet("/_private/admin/organisations", {}),
   });
 
-  if (result.isError) {
-    throw result.error;
-  }
+  const handleDeleteClick = (id: string, name: string) => {
+    setSelectedOrganisation({ id, name });
+    modal.open();
+  };
 
-  if (result.isLoading || result.isPending) {
-    return <Loading />;
-  }
+  const handleConfirmDelete = useCallback(() => {
+    if (selectedOrganisation) {
+      deleteOrganisation.mutate(
+        { id: selectedOrganisation.id },
+        {
+          onSuccess: () => {
+            modal.close();
+          },
+        }
+      );
+    }
+  }, [deleteOrganisation, selectedOrganisation, modal]);
+
+  const deleteError = deleteOrganisation.isError ? "Une erreur est survenue lors de la suppression." : null;
 
   return (
     <>
@@ -45,7 +75,7 @@ export default function OrganisationList({ lang }: WithLang) {
             field: "actions",
             type: "actions",
             headerName: "Actions",
-            getActions: ({ row: { _id } }) => [
+            getActions: ({ row: { _id, nom } }) => [
               <Button
                 key="view"
                 iconId="fr-icon-arrow-right-line"
@@ -53,12 +83,46 @@ export default function OrganisationList({ lang }: WithLang) {
                   href: PAGES.dynamic.adminOrganisationView(_id).getPath(lang),
                 }}
                 priority="tertiary no outline"
-                title="Voir l'utilisateur"
+                title="Voir l'organisation"
+              />,
+              <Button
+                key="delete"
+                iconId="fr-icon-close-line"
+                priority="tertiary no outline"
+                title="Supprimer l'organisation"
+                nativeButtonProps={modal.buttonProps}
+                onClick={() => handleDeleteClick(_id, nom)}
               />,
             ],
           },
         ]}
       />
+
+      <modal.Component
+        title={`Supprimer l'organisation "${selectedOrganisation?.name}" ?`}
+        buttons={[
+          {
+            children: "Annuler",
+            disabled: deleteOrganisation.isPending,
+          },
+          {
+            onClick: handleConfirmDelete,
+            children: "Confirmer la suppression",
+            disabled: deleteOrganisation.isPending,
+            doClosesModal: false,
+          },
+        ]}
+      >
+        <Typography>
+          Êtes-vous sûr de vouloir supprimer cette organisation ? Cette action est irréversible et tous les utilisateurs
+          rattachés à cette organisation se retrouveront sans organisation.
+        </Typography>
+        {deleteError && (
+          <Box sx={{ marginTop: fr.spacing("2w") }}>
+            <Alert description={deleteError} severity="error" small />
+          </Box>
+        )}
+      </modal.Component>
     </>
   );
 }


### PR DESCRIPTION
Ajout du mécanisme pour supprimer une organisation, en détachant tous les utilisateurs liés si nécessaires :

- [x] [Server] [Ajout d'action de suppression d'organisation coté server](https://github.com/mission-apprentissage/api-apprentissage/pull/330/commits/a098401f776d05a6ab71fe22c6337fd81999139d)
- [x] [Server] [Ajout de la route de suppression d'organisation](https://github.com/mission-apprentissage/api-apprentissage/pull/330/commits/b6f60b752e84f0fbf73fe222592479dcf07bf059)
- [x] [Ui] [Ajout d'un hook de suppression d'organisantion / gestion useQuery
](https://github.com/mission-apprentissage/api-apprentissage/pull/330/commits/7f78f459baa389f52af22ea8a6d87a9aa15da2c7)
- [x] [Ui] [Ajout d'un bouton et d'une modale de confirmation dans le composant de liste des organisations](https://github.com/mission-apprentissage/api-apprentissage/pull/330/commits/7f78f459baa389f52af22ea8a6d87a9aa15da2c7)
---

- ⚠️ J'ai pas réussi à utiliser les icones remixIcons du dsfr bizarrement, voir si nécessaire d'update le package react-dsfr
- ⚠️ Pas de tests sur les actions et routes coté server pour tous les composants d'admin, à voir si on prévoit d'en ajouter un jour
- ⚠️ Problématique windows / git.bash pour le seed de la DB, non prio à traiter plus tard

