### PR TITLE
fix: exemple post job valeur target_diploma.european

### DIFF
--- a/sdk/src/docs/models/job/offer_read.model.doc.ts
+++ b/sdk/src/docs/models/job/offer_read.model.doc.ts
@@ -120,7 +120,7 @@ export const offerReadModelDoc = {
           properties: {
             european: {
               descriptions: [{ en: "Targeted diploma level at the end of studies.", fr: null }],
-              examples: [3],
+              examples: ["3"],
             },
             label: {
               descriptions: [{ en: "The title of the targeted diploma level at the end of studies.", fr: null }],


### PR DESCRIPTION
Correction de l'exemple postJob sur le champ target_diploma.european