### PR TITLE
feature : downgrade NextJs to 15.1.4

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
     "jwt-decode": "^4.0.0",
     "match-sorter": "^8.0.0",
     "mobx": "^6.13.6",
-    "next": "^15.2.0",
+    "next": "15.1.4",
     "next-plausible": "^3.12.4",
     "notion-client": "^7.1.6",
     "react": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,10 +1780,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/env@npm:15.2.0"
-  checksum: 3ea15f0126d0fa623cb3ac84956f024c5d2ff9a81c8d4da71dc82bb6a32cdd8fd115c4cd250117de22a9ec06d71d20e5c07b7cbedf1dc575cc684c0acda9e29a
+"@next/env@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/env@npm:15.1.4"
+  checksum: bb26fa2184a81d0d5265962d4f162f32d5a5a19281af475ab32e13bd700b4cf32164ca4add9fd1f849f4c970bad7a7cca25ed3414e94396472a94e2d567c4600
   languageName: node
   linkType: hard
 
@@ -1796,58 +1796,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-darwin-arm64@npm:15.2.0"
+"@next/swc-darwin-arm64@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-darwin-arm64@npm:15.1.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-darwin-x64@npm:15.2.0"
+"@next/swc-darwin-x64@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-darwin-x64@npm:15.1.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-linux-arm64-gnu@npm:15.2.0"
+"@next/swc-linux-arm64-gnu@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.1.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-linux-arm64-musl@npm:15.2.0"
+"@next/swc-linux-arm64-musl@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-linux-arm64-musl@npm:15.1.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-linux-x64-gnu@npm:15.2.0"
+"@next/swc-linux-x64-gnu@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-linux-x64-gnu@npm:15.1.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-linux-x64-musl@npm:15.2.0"
+"@next/swc-linux-x64-musl@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-linux-x64-musl@npm:15.1.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-win32-arm64-msvc@npm:15.2.0"
+"@next/swc-win32-arm64-msvc@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.1.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:15.2.0":
-  version: 15.2.0
-  resolution: "@next/swc-win32-x64-msvc@npm:15.2.0"
+"@next/swc-win32-x64-msvc@npm:15.1.4":
+  version: 15.1.4
+  resolution: "@next/swc-win32-x64-msvc@npm:15.1.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -12486,19 +12486,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^15.2.0":
-  version: 15.2.0
-  resolution: "next@npm:15.2.0"
+"next@npm:15.1.4":
+  version: 15.1.4
+  resolution: "next@npm:15.1.4"
   dependencies:
-    "@next/env": 15.2.0
-    "@next/swc-darwin-arm64": 15.2.0
-    "@next/swc-darwin-x64": 15.2.0
-    "@next/swc-linux-arm64-gnu": 15.2.0
-    "@next/swc-linux-arm64-musl": 15.2.0
-    "@next/swc-linux-x64-gnu": 15.2.0
-    "@next/swc-linux-x64-musl": 15.2.0
-    "@next/swc-win32-arm64-msvc": 15.2.0
-    "@next/swc-win32-x64-msvc": 15.2.0
+    "@next/env": 15.1.4
+    "@next/swc-darwin-arm64": 15.1.4
+    "@next/swc-darwin-x64": 15.1.4
+    "@next/swc-linux-arm64-gnu": 15.1.4
+    "@next/swc-linux-arm64-musl": 15.1.4
+    "@next/swc-linux-x64-gnu": 15.1.4
+    "@next/swc-linux-x64-musl": 15.1.4
+    "@next/swc-win32-arm64-msvc": 15.1.4
+    "@next/swc-win32-x64-msvc": 15.1.4
     "@swc/counter": 0.1.3
     "@swc/helpers": 0.5.15
     busboy: 1.6.0
@@ -12543,7 +12543,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: cc979f71843c345710f7fef012fead1f59a868f636979c2d0013756f235644e768c608b515921afa48a3ad2773a7b82d728fa509c7eb2c4d26d2fcafc10c41a7
+  checksum: e9de936fe41bdddd50be283b6ce1f35ef434f0777026400a9119d91d0f99d0f7d7101599700de7502b0340c247691f98abea551c1738f158c89d4981d11fe1cf
   languageName: node
   linkType: hard
 
@@ -17114,7 +17114,7 @@ __metadata:
     jwt-decode: ^4.0.0
     match-sorter: ^8.0.0
     mobx: ^6.13.6
-    next: ^15.2.0
+    next: 15.1.4
     next-plausible: ^3.12.4
     notion-client: ^7.1.6
     notion-types: ^7.1.6


### PR DESCRIPTION
Je propose (temporairement) un downgrade vers NextJs 15.1.4 pour pouvoir déployer et ensuite identifier les libraires broken par l'update.

👁️ https://github.com/vercel/next.js/issues/74826