### PR TITLE
feat(lba-2930): précision documentation sur l'api candidature

### DIFF
--- a/sdk/src/docs/metier/candidature-offre/candidature-offre.doc.ts
+++ b/sdk/src/docs/metier/candidature-offre/candidature-offre.doc.ts
@@ -70,8 +70,8 @@ export const candidatureOffrePageDoc = {
             applicant_attachment_content: {
               description: { en: "Resume file", fr: "CV du candidat." },
               information: {
-                en: "The file must be base64 encoded and only PDF and DOCX format are allowed. File size must be under 3MB.",
-                fr: "Le CV doit être encodé en base64, et seuls les formats PDF et DOCX sont autorisés. La taille du fichier ne doit pas dépasser 3 Mo.",
+                en: "The file must be base64 encoded and only PDF and DOCX format are allowed. File size must be under 3MB. File content-type and base64 encoding must prefix the Base64 encoded content. Ex : data:application/pdf;base64,<base64_encoded_content>",
+                fr: "Le CV doit être encodé en base64, et seuls les formats PDF et DOCX sont autorisés. La taille du fichier ne doit pas dépasser 3 Mo. Le content-type du fichier et la mention de l'encodage en Base64 doivent préfixer le contenu encodé. Ex : data:application/pdf;base64,<contenu_encodé_base64>",
               },
             },
             applicant_attachment_name: {

--- a/sdk/src/docs/metier/candidature-offre/candidature-offre.doc.ts
+++ b/sdk/src/docs/metier/candidature-offre/candidature-offre.doc.ts
@@ -68,7 +68,10 @@ export const candidatureOffrePageDoc = {
           name: { en: "Content", fr: "Contenu" },
           rows: {
             applicant_attachment_content: {
-              description: { en: "Resume file base64 encoded. File content-type and base64 encoding must prefix the Base64 encoded content. Ex : 'data:application/pdf;base64,<base64_encoded_content>'", fr: "CV du candidat encodé en base64. Le content-type du fichier et la mention de l'encodage en base64 doivent préfixer le contenu encodé. Ex : 'data:application/pdf;base64,<contenu_encodé_base64>'" },
+              description: {
+                en: "Resume file base64 encoded. File content-type and base64 encoding must prefix the Base64 encoded content. Ex : 'data:application/pdf;base64,<base64_encoded_content>'",
+                fr: "CV du candidat encodé en base64. Le content-type du fichier et la mention de l'encodage en base64 doivent préfixer le contenu encodé. Ex : 'data:application/pdf;base64,<contenu_encodé_base64>'",
+              },
               information: {
                 en: "The file must be base64 encoded and only PDF and DOCX format are allowed. File size must be under 3MB. File content-type and base64 encoding must prefix the Base64 encoded content. Ex : data:application/pdf;base64,<base64_encoded_content>",
                 fr: "Le CV doit être encodé en base64, et seuls les formats PDF et DOCX sont autorisés. La taille du fichier ne doit pas dépasser 3 Mo. Le content-type du fichier et la mention de l'encodage en Base64 doivent préfixer le contenu encodé. Ex : data:application/pdf;base64,<contenu_encodé_base64>",

--- a/sdk/src/docs/metier/candidature-offre/candidature-offre.doc.ts
+++ b/sdk/src/docs/metier/candidature-offre/candidature-offre.doc.ts
@@ -68,7 +68,7 @@ export const candidatureOffrePageDoc = {
           name: { en: "Content", fr: "Contenu" },
           rows: {
             applicant_attachment_content: {
-              description: { en: "Resume file", fr: "CV du candidat." },
+              description: { en: "Resume file base64 encoded. File content-type and base64 encoding must prefix the Base64 encoded content. Ex : 'data:application/pdf;base64,<base64_encoded_content>'", fr: "CV du candidat encodé en base64. Le content-type du fichier et la mention de l'encodage en base64 doivent préfixer le contenu encodé. Ex : 'data:application/pdf;base64,<contenu_encodé_base64>'" },
               information: {
                 en: "The file must be base64 encoded and only PDF and DOCX format are allowed. File size must be under 3MB. File content-type and base64 encoding must prefix the Base64 encoded content. Ex : data:application/pdf;base64,<base64_encoded_content>",
                 fr: "Le CV doit être encodé en base64, et seuls les formats PDF et DOCX sont autorisés. La taille du fichier ne doit pas dépasser 3 Mo. Le content-type du fichier et la mention de l'encodage en Base64 doivent préfixer le contenu encodé. Ex : data:application/pdf;base64,<contenu_encodé_base64>",


### PR DESCRIPTION
Des utilisateurs de l'api mettent directement le contenu encodé en base64 dans le champ correspondant sans ajouter la mention du content-type et de l'encodage.
De ce fait le traitement des pièces jointes échoue de manière invisible alors que le dépôt de candidature a bien lieu.