### PR TITLE
fix(lba-3822): ajouter un timeout sur les requêtes forwardées vers LBA

### DIFF
--- a/server/src/server/routes/job/job.routes.ts
+++ b/server/src/server/routes/job/job.routes.ts
@@ -161,7 +161,6 @@ export const jobRoutes = ({ server }: { server: Server }) => {
           endpoint: config.api.lba.endpoint,
           path: `/v3/jobs/export`,
           requestInit: { method: "GET" },
-          timeoutMs: 60_000,
         },
         response,
         { user, organisation: request.organisation ?? null }

--- a/server/src/server/routes/job/job.routes.ts
+++ b/server/src/server/routes/job/job.routes.ts
@@ -161,6 +161,7 @@ export const jobRoutes = ({ server }: { server: Server }) => {
           endpoint: config.api.lba.endpoint,
           path: `/v3/jobs/export`,
           requestInit: { method: "GET" },
+          timeoutMs: 60_000,
         },
         response,
         { user, organisation: request.organisation ?? null }

--- a/server/src/services/forward/forwardApi.service.test.ts
+++ b/server/src/services/forward/forwardApi.service.test.ts
@@ -293,4 +293,25 @@ describe("forwardApi.service", () => {
     expect(response.statusCode).toBe(403);
     expect(response.json()).toEqual(responseBody);
   });
+
+  it("should return 500 when the upstream response exceeds timeoutMs", async () => {
+    nock(baseUrl).get("/v3/jobs/search").delay(500).reply(200, { success: true });
+
+    app.get("/test", async (_req, reply) => {
+      await forwardApiRequest(
+        { endpoint: baseUrl, path: "/v3/jobs/search", requestInit: { method: "GET" }, timeoutMs: 50 },
+        reply,
+        { user: basicUser, organisation: null }
+      );
+    });
+
+    const response = await app.inject({ method: "GET", url: "/test" });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({
+      message: "The server was unable to complete your request",
+      name: "Internal Server Error",
+      statusCode: 500,
+    });
+  });
 });

--- a/server/src/services/forward/forwardApi.service.ts
+++ b/server/src/services/forward/forwardApi.service.ts
@@ -8,7 +8,13 @@ import type { IUser } from "shared/models/user.model";
 import config from "@/config.js";
 import { withCause } from "@/services/errors/withCause.js";
 
-type ForwardApiRequestConfig = { endpoint: string; path: string; querystring?: string; requestInit: RequestInit };
+type ForwardApiRequestConfig = {
+  endpoint: string;
+  path: string;
+  querystring?: string;
+  requestInit: RequestInit;
+  timeoutMs?: number;
+};
 
 type Identity = { user: IUser; organisation: IOrganisationInternal | null };
 
@@ -41,6 +47,10 @@ export async function createAuthToken(
 }
 
 async function getResponse(request: ForwardApiRequestConfig, identity: Identity): Promise<Response> {
+  const timeoutMs = request.timeoutMs ?? 10_000;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
   try {
     const url = request.endpoint + request.path + (request.querystring ?? "");
 
@@ -49,7 +59,7 @@ async function getResponse(request: ForwardApiRequestConfig, identity: Identity)
 
     headers.append("Authorization", await createAuthToken(identity));
 
-    const response = await fetch(url, { ...request.requestInit, headers });
+    const response = await fetch(url, { ...request.requestInit, headers, signal: controller.signal });
 
     if (response.status === 401) {
       throw internal("forwardApi.getResponse: unauthorized", {
@@ -61,7 +71,12 @@ async function getResponse(request: ForwardApiRequestConfig, identity: Identity)
 
     return response;
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw internal("forwardApi.getResponse: timeout", { request, timeoutMs });
+    }
     throw withCause(internal("forwardApi.getResponse: unexpected error", { request }), error);
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/mission-apprentissage/labonnealternance/issues/4591

---

## Contexte

Des pics d'erreurs 500 sur la route `/api/job/v1/search` ont été observés, corrélés avec des périodes de forte charge (notamment à minuit lors du déclenchement simultané de plusieurs importers). La cause : le `fetch` vers l'API LBA n'avait aucun timeout — si LBA était lent ou injoignable, les requêtes s'accumulaient en mémoire sans jamais être annulées, pouvant provoquer un OOM kill des replicas.

## Changements

- Ajout d'un `AbortController` avec timeout dans `forwardApiRequest` (via `getResponse`)
- Timeout par défaut : **10 secondes** pour toutes les routes (search, offer, apply…)
- Le timeout est configurable via le champ `timeoutMs` dans `ForwardApiRequestConfig`
- En cas de timeout, une erreur 500 propre est levée avec le message `forwardApi.getResponse: timeout`

## Plan de test

- [x] Appeler `/api/job/v1/search` avec des paramètres valides → réponse normale en < 10s
- [ ] Simuler un LBA lent (ex: via proxy avec délai) → vérifier qu'on reçoit bien une 500 après ~10s et non un hang indéfini