### PR TITLE
feat: lba-3864 suppression du champ origin de la doc

### DIFF
--- a/sdk/src/docs/models/job/offer_write.model.doc.ts
+++ b/sdk/src/docs/models/job/offer_write.model.doc.ts
@@ -28,11 +28,6 @@ export const offerWriteModelDoc = {
             },
           ],
         },
-        origin: {
-          descriptions: [
-            { fr: "Origine de l'offre provenant d'un aggregateur", en: "Origin of the offer from an aggregator" },
-          ],
-        },
         rome_codes: {
           descriptions: [
             { en: "ROME code(s) of the offer", fr: "Code(s) ROME de l'offre" },

--- a/sdk/src/docs/models/job/offer_write.model.doc.ts
+++ b/sdk/src/docs/models/job/offer_write.model.doc.ts
@@ -28,6 +28,9 @@ export const offerWriteModelDoc = {
             },
           ],
         },
+        origin: {
+          descriptions: [{ fr: "Déprécié", en: "Deprecated" }],
+        },
         rome_codes: {
           descriptions: [
             { en: "ROME code(s) of the offer", fr: "Code(s) ROME de l'offre" },

--- a/sdk/src/models/job/job.model.openapi.ts
+++ b/sdk/src/models/job/job.model.openapi.ts
@@ -354,6 +354,10 @@ const offerWriteSchema = {
           description: "Si l'offre peut être diffusé sur l'ensemble des plateformes partenaires",
           default: true,
         },
+        origin: {
+          type: ["string", "null"],
+          description: "Déprécié",
+        },
         status: {
           ...offerReadSchema.properties.offer.properties.status,
           default: "Active",

--- a/sdk/src/models/job/job.model.openapi.ts
+++ b/sdk/src/models/job/job.model.openapi.ts
@@ -354,10 +354,6 @@ const offerWriteSchema = {
           description: "Si l'offre peut être diffusé sur l'ensemble des plateformes partenaires",
           default: true,
         },
-        origin: {
-          type: ["string", "null"],
-          description: "Origine de l'offre provenant d'un aggregateur",
-        },
         status: {
           ...offerReadSchema.properties.offer.properties.status,
           default: "Active",

--- a/sdk/src/openapi/__snapshots__/openapiSpec.test.ts.snap
+++ b/sdk/src/openapi/__snapshots__/openapiSpec.test.ts.snap
@@ -2589,13 +2589,6 @@ exports[`openapiSpec#models > should generate proper schema JobOfferWrite 1`] = 
           ],
           "type": "number",
         },
-        "origin": {
-          "description": "Origine de l'offre provenant d'un aggregateur",
-          "type": [
-            "string",
-            "null",
-          ],
-        },
         "publication": {
           "properties": {
             "creation": {

--- a/sdk/src/openapi/__snapshots__/openapiSpec.test.ts.snap
+++ b/sdk/src/openapi/__snapshots__/openapiSpec.test.ts.snap
@@ -2589,6 +2589,13 @@ exports[`openapiSpec#models > should generate proper schema JobOfferWrite 1`] = 
           ],
           "type": "number",
         },
+        "origin": {
+          "description": "Déprécié",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
         "publication": {
           "properties": {
             "creation": {

--- a/shared/src/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/src/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -2916,6 +2916,13 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
                 ],
                 "type": "number",
               },
+              "origin": {
+                "description": "Déprécié",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
               "publication": {
                 "properties": {
                   "creation": {

--- a/shared/src/openapi/__snapshots__/generateOpenapi.test.ts.snap
+++ b/shared/src/openapi/__snapshots__/generateOpenapi.test.ts.snap
@@ -2916,13 +2916,6 @@ exports[`generateOpenApiSchema > should generate proper schema 1`] = `
                 ],
                 "type": "number",
               },
-              "origin": {
-                "description": "Origine de l'offre provenant d'un aggregateur",
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
               "publication": {
                 "properties": {
                   "creation": {


### PR DESCRIPTION
Le champ origin n'est plus interprété côté labonnealternance 
Son utilisation n'est pas interdite par l'api par contre il sera mentionné comme déprécié dans la documentation