### PR TITLE
fix: retourne 504 au lieu de 500 sur timeout du forward vers LBA

### DIFF
--- a/server/src/services/forward/forwardApi.service.test.ts
+++ b/server/src/services/forward/forwardApi.service.test.ts
@@ -294,7 +294,7 @@ describe("forwardApi.service", () => {
     expect(response.json()).toEqual(responseBody);
   });
 
-  it("should return 500 when the upstream response exceeds timeoutMs", async () => {
+  it("should return 504 when the upstream response exceeds timeoutMs", async () => {
     nock(baseUrl).get("/v3/jobs/search").delay(500).reply(200, { success: true });
 
     app.get("/test", async (_req, reply) => {
@@ -307,11 +307,11 @@ describe("forwardApi.service", () => {
 
     const response = await app.inject({ method: "GET", url: "/test" });
 
-    expect(response.statusCode).toBe(500);
+    expect(response.statusCode).toBe(504);
     expect(response.json()).toEqual({
       message: "The server was unable to complete your request",
-      name: "Internal Server Error",
-      statusCode: 500,
+      name: "Gateway Time-out",
+      statusCode: 504,
     });
   });
 });

--- a/server/src/services/forward/forwardApi.service.ts
+++ b/server/src/services/forward/forwardApi.service.ts
@@ -1,4 +1,4 @@
-import { internal } from "@hapi/boom";
+import { gatewayTimeout, internal } from "@hapi/boom";
 import { createApiAlternanceToken } from "api-alternance-sdk";
 import type { FastifyReply } from "fastify";
 import type { HttpHeader } from "fastify/types/utils.js";
@@ -72,7 +72,7 @@ async function getResponse(request: ForwardApiRequestConfig, identity: Identity)
     return response;
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
-      throw internal("forwardApi.getResponse: timeout", { request, timeoutMs });
+      throw gatewayTimeout("forwardApi.getResponse: timeout", { request, timeoutMs });
     }
     throw withCause(internal("forwardApi.getResponse: unexpected error", { request }), error);
   } finally {


### PR DESCRIPTION
## Contexte

Le 28/07 (16h33–17h25), ~2 500 erreurs 500 ont été renvoyées aux consommateurs : LBA ne répondait plus et le forward timeoutait à 10s (`forwardApi.getResponse: timeout`). Routes touchées : `GET /api/job/v1/search` et `POST /api/formation/v1/appointment/generate-link`. Un 500 est indiscernable d'un bug interne pour les consommateurs.

## Changements

- `forwardApi.service.ts` : le timeout du forward lève désormais `gatewayTimeout()` (504) au lieu de `internal()` (500)
- Test mis à jour en conséquence

Sentry continue de capturer ces erreurs (le middleware capture tout statusCode >= 500).

## Test

- [x] `yarn test --run server/src/services/forward/forwardApi.service.test.ts` — 8 passed